### PR TITLE
Allow strings in steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ MANIFEST
 env
 .coverage
 build
+*~
+\#*
+\.\#*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
+script: nosetests 

--- a/pyspecs/_step.py
+++ b/pyspecs/_step.py
@@ -86,6 +86,12 @@ class Step(object):
         self._name = item
         return self
 
+    def __call__(self, *args):
+        if len(args) != 1:
+            raise AttributeError('You may only specify a single name')
+        self._name = ''.join([x if ord(x) < 128 else '-' for x in args[0]])
+        return self
+
     def __enter__(self):
         self._counter.start(self.name)
         return self

--- a/tests/test_named.py
+++ b/tests/test_named.py
@@ -1,0 +1,50 @@
+import sys
+from itertools import count
+from unittest import TestCase
+from pyspecs._step import _StepCounter, Step
+
+
+class FakeReporter(object):
+    def __init__(self):
+        self.received = None
+
+    def report(self, step_report):
+        self.received = step_report
+
+
+class TestSingleNamedStep(TestCase):
+    def test(self):
+        timer = count()
+        reporter = FakeReporter()
+        counter = _StepCounter(reporter, timer.next)
+        given = Step('given', counter)
+
+        with given("something with spaces"):
+            pass
+
+        report = reporter.received
+        self.assertEqual('given something with spaces', report.name)
+
+
+class TestUnicodeNameStep(TestCase):
+    def test(self):
+        timer = count()
+        reporter = FakeReporter()
+        counter = _StepCounter(reporter, timer.next)
+        given = Step('given', counter)
+
+        with given(
+                u"\xe1\xe9\xed\xf3\xfa "  # tilde
+                u"\xe0\xe8\xec\xf2\xf9 "  # back tilde
+                u"\xe2\xea\xee\xf4\xfb "  # circumflex
+                u"\xe4\xeb\xef\xf6\xff "  # dieresis
+                u"\xf1\xd1 " # n tilde
+                u"\xe7\xc7 " # c cedilla
+                u"\xdf\xa7"  # B umlaud
+        ):
+            pass
+
+        report = reporter.received
+        self.assertEqual('given ----- ----- ----- ----- -- -- --', report.name)
+
+


### PR DESCRIPTION
Two small changes:
- ignore emacs backup files in .gitignore
- added travis configuration to test it (you can configure it for the main repository; mine is here: https://travis-ci.org/magmax/pyspecs)

And a big one:

Instead of using "given.a_new_string", you can use: "given('a new string')". This allows to use spaces instead of underscores, which are more difficult to type in some keyboard languages (like Spanish).

Old format will remain supported.
